### PR TITLE
shell.sh: made the script compatible with mac

### DIFF
--- a/docker/shell.sh
+++ b/docker/shell.sh
@@ -6,7 +6,15 @@ else
     DEV=$1
 fi
 
-LOC_PATH=$(readlink -f $0|sed -r 's/[^/]+\/[^/]+$//')
+READLINK=readlink
+SED=sed
+
+[ $(uname) = "Darwin" ] && {
+    READLINK=greadlink
+    SED=gsed
+}
+
+LOC_PATH=$($READLINK -f $0 | $SED -r 's/[^/]+\/[^/]+$//')
 echo
 echo "Mapped Path  : $LOC_PATH"
 echo "Mapped Device: $DEV"


### PR DESCRIPTION
The BSD readline doesn't have the -f parameter and the BSD sed doesn't
have the -r parameter. These are specific to their GNU counterparts.
When the script is used on a mac, it'll use greadline and gsed instead.